### PR TITLE
3 allow long hash

### DIFF
--- a/django_querycache/cacheman.py
+++ b/django_querycache/cacheman.py
@@ -116,7 +116,7 @@ class RowHash(RowFullHash):
     This returns the md5 hash, truncated to 8 characters for easier handling.
     """
 
-    template = 'substring(%(function)s("%(table)s"::text) from 0 for 8)'
+    template = 'substring(%(function)s("%(table)s"::text) for 8)'
 
 
 class SomeColsFullHash(RowFullHash):
@@ -124,7 +124,7 @@ class SomeColsFullHash(RowFullHash):
     Trick to return the md5sum of only some columns
     """
 
-    template = "substring(%(function)s(%(expressions)s) from 0 for 8)"
+    template = "substring(%(function)s(%(expressions)s) for 8)"
 
     def as_sql(self, compiler, connection, function=None, template=None, arg_joiner="||", **extra_context):
         """

--- a/django_querycache/tests/tests.py
+++ b/django_querycache/tests/tests.py
@@ -165,15 +165,21 @@ class TestFullHashTestCase(TestCase):
     Test that we can fetch the "full hash" of a table if desired for greater accuracy
     """
 
-    def test_long_fingerprint(self):
-        # A fingerprint can be generated from a model
-        fp_from_model = Fingerprinting(ModelOfRandomness)
+    def setUp(self):
+        for n in range(5):
+            ModelOfRandomness().save()
 
-        # A fingerprint can be generated from a model
+    def test_long_fingerprint(self):
+        """
+        A lng fingerprint should be 32 chars
+        A short fingerprint should be 8 chars
+        The output of a short fingerprint should
+        be the same as the first 8 chars of the output
+        of a long fingerprint
+        """
+        fp_from_model = Fingerprinting(ModelOfRandomness)
         fp_from_model_long = Fingerprinting(ModelOfRandomness, long_hash=True)
 
         self.assertEqual(fp_from_model_long.query_fingerprint()[:8], fp_from_model.query_fingerprint())
         self.assertEqual(len(fp_from_model.query_fingerprint()), 8)
         self.assertEqual(len(fp_from_model_long.query_fingerprint()), 32)
-
-        logger.debug(fp_from_model.query_fingerprint())

--- a/django_querycache/tests/tests.py
+++ b/django_querycache/tests/tests.py
@@ -158,3 +158,22 @@ class CachedQuerySetTestCase(TestCase):
             ),
             geojson_props=("pk", "category"),
         ).get_with_update()
+
+
+class TestFullHashTestCase(TestCase):
+    """
+    Test that we can fetch the "full hash" of a table if desired for greater accuracy
+    """
+
+    def test_long_fingerprint(self):
+        # A fingerprint can be generated from a model
+        fp_from_model = Fingerprinting(ModelOfRandomness)
+
+        # A fingerprint can be generated from a model
+        fp_from_model_long = Fingerprinting(ModelOfRandomness, long_hash=True)
+
+        self.assertEqual(fp_from_model_long.query_fingerprint()[:8], fp_from_model.query_fingerprint())
+        self.assertEqual(len(fp_from_model.query_fingerprint()), 8)
+        self.assertEqual(len(fp_from_model_long.query_fingerprint()), 32)
+
+        logger.debug(fp_from_model.query_fingerprint())


### PR DESCRIPTION
Closes #3

## Description
Adds ability to hash 32 characters instead of 8 for table and row content

## Explanation of the solution
A flag on `Fingerprinting` to set long hash to true. This is opt in: Default behavior of 8 character hash is retained.
