### PR TITLE
Hash includes row count

### DIFF
--- a/django_querycache/tests/test_settings.py
+++ b/django_querycache/tests/test_settings.py
@@ -9,6 +9,7 @@ DATABASES = {
         "PASSWORD": "post1233",
         "HOST": "localhost",
         "PORT": "49158",
+        "NAME": "postgres",
     }
 }
 


### PR DESCRIPTION
Closes #

## Description

Deleted rows change the fingerprint of a table

## Explanation of the solution

The row count is included in the hash function along with last updated datetime
