### PR TITLE
Codecoverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source=django_querycache

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -236,7 +236,12 @@ jobs:
                   sudo apt-get install binutils libproj-dev gdal-bin python3-psycopg2
 
             - name: Run Tests
-              run: poetry run django_querycache/runtests.py
+              run: poetry run coverage run django_querycache/runtests.py
+
+            - name: "Upload coverage to Codecov"
+              uses: codecov/codecov-action@v2
+              with:
+                fail_ci_if_error: true
 
             # Service containers to run postgres
         services:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -238,6 +238,9 @@ jobs:
             - name: Run Tests
               run: poetry run coverage run django_querycache/runtests.py
 
+            - name: Produce coverage XML
+              run: poetry run coverage xml
+
             - name: "Upload coverage to Codecov"
               uses: codecov/codecov-action@v2
               with:

--- a/django_querycache/runtests.py
+++ b/django_querycache/runtests.py
@@ -3,7 +3,6 @@ import os
 import sys
 
 import django
-from coverage import Coverage
 from django.conf import settings
 from django.test.utils import get_runner
 
@@ -12,11 +11,5 @@ if __name__ == "__main__":
     django.setup()
     TestRunner = get_runner(settings)
     test_runner = TestRunner()
-    cov = Coverage()
-    cov.erase()
-    cov.start()
     failures = test_runner.run_tests(["tests"])
-    cov.stop()
-    cov.save()
-    covered = cov.report()
     sys.exit(bool(failures))


### PR DESCRIPTION
Closes #

## Description

This PR adds test coverage report uploads to track how much code is/is not being hit in testing

## Explanation of the solution

Following quides from codecov, the action now uploads the test coverage report
