### PR TITLE
Add drf headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,18 @@ From the root directory run tests with
 poetry run django_querycache/runtests.py
 ```
 
-This uses the test setting in `tests`. You may wish to set an env variable for a different settings if you want to use a different setup (note tests use the postgis container specified in the github actions
+This uses the test setting in `tests`. You may wish to set an env variable for a different settings if you want to use a different setup (note tests use the postgis container specified in the github actions)
+
+To run the container as specified in the actions, run a postgres container on 49158 with password `post1233`
+
+```sh
+docker run \
+    --rm \
+    -p 49158:5432 \
+    -e POSTGRES_PASSWORD="post1233" \
+    postgis/postgis:12-3.1 \
+    -c fsync=off
+```
 
 ### Github Actions
 

--- a/django_querycache/drf_mixins.py
+++ b/django_querycache/drf_mixins.py
@@ -15,14 +15,17 @@ except ModuleNotFoundError:
 class ViewsetProto(Protocol):
     def filter_queryset(self, qs: QuerySet) -> QuerySet:
         ...
+
     def get_queryset(self) -> QuerySet:
         ...
+
     @property
     def serializer_class(self) -> Any:
         ...
 
+
 class AddHeadersMixin:
-    def _add_headers(self:ViewsetProto, object=None) -> Tuple[Tuple[str, str], ...]:
+    def _add_headers(self: ViewsetProto, object=None) -> Tuple[Tuple[str, str], ...]:
         queryset = self.filter_queryset(self.get_queryset())  # type: QuerySet
         if object:
             queryset = queryset.filter(pk=object.pk)

--- a/django_querycache/drf_mixins.py
+++ b/django_querycache/drf_mixins.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Tuple, Protocol
+from typing import Any, Protocol, Tuple
 
 from django.db.models import QuerySet
 

--- a/django_querycache/drf_mixins.py
+++ b/django_querycache/drf_mixins.py
@@ -1,0 +1,71 @@
+from http import HTTPStatus
+from typing import Tuple
+
+from django.db.models import QuerySet
+
+from .fingerprinting import Fingerprinting
+from .utils import last_modified_queryset
+
+try:
+    from rest_framework.response import Response
+except ModuleNotFoundError:
+    raise ModuleNotFoundError("Django rest framework is required for this feature")
+
+
+class AddHeadersMixin:
+    def _add_headers(self, object=None) -> Tuple[Tuple[str, str]]:
+        queryset = self.filter_queryset(self.get_queryset())
+        if object:
+            queryset = queryset.filter(pk=object.pk)
+
+        last_modified = last_modified_queryset(queryset)
+        etag = Fingerprinting(query=queryset, hashfields=self.serializer_class.Meta.fields).query_fingerprint()
+        headers: Tuple[Tuple[str, str]] = (("Last-Modified", last_modified), ("ETag", etag))
+
+        return headers
+
+
+class ListHeadersMixin:
+    def list(self, request, *args, **kwargs):
+        queryset: QuerySet = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data, headers=self._add_headers())
+
+        serializer = self.get_serializer(queryset, many=True)
+
+        headers = dict(self._add_headers())
+        # Return a 304: Unchanged if the ETag and Last-Modified match
+        if "If-None-Match" in request.headers and request.headers.get("If-None-Match") == headers["ETag"]:
+            return Response(status=HTTPStatus.NOT_MODIFIED)
+
+        return Response(serializer.data, headers=headers)
+
+
+class RetrieveHeadersMixin:
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = self.get_serializer(instance)
+
+        headers = dict(self._add_headers())
+        # Return a 304: Unchanged if the ETag and Last-Modified match
+        if "If-None-Match" in request.headers and request.headers.get("If-None-Match") == headers["ETag"]:
+            return Response(status=HTTPStatus.NOT_MODIFIED)
+
+        return Response(serializer.data, headers=headers)
+
+
+class ModelViewSetHeaders(AddHeadersMixin, ListHeadersMixin, RetrieveHeadersMixin):
+    """
+    Class modifies the "list" and "retrieve" actions
+    to generate an ETag and Last-Modified. If there 
+    are no changes a 304 response is returned.
+
+    To use this class, add it as the first superclass
+    to a Viewset. For instance:
+    
+    >>> class SIPRequirementValuesViewSet(ModelViewSetHeaders, viewsets.ModelViewSet):
+    
+    """
+    pass

--- a/django_querycache/fingerprinting.py
+++ b/django_querycache/fingerprinting.py
@@ -11,7 +11,7 @@ from django.db.models.aggregates import Count, Max
 
 from .hashfunctions import RowFullHash, RowHash, SomeColsFullHash, SomeColsHash
 from .type_annotations import InputModel, hstring
-from .utils import get_query_cache, inputmodel_parse, query_to_key, utcnow
+from .utils import get_query_cache, get_ts_field, inputmodel_parse, query_to_key, utcnow
 
 logger = logging.getLogger(__name__)
 
@@ -201,10 +201,8 @@ class TimeStampedFingerprint(Fingerprinting):
         if "timestamp_column" in kwargs:
             self.timestamp_column = kwargs.pop("timestamp_column")
         else:
-            for field in self.model._meta.fields:
-                if hasattr(field, "auto_now") and field.auto_now is True:
-                    self.timestamp_column = field.name
-                    break
+            if field := get_ts_field(self.model):
+                self.timestamp_column = field.name
         if not self.timestamp_column:
             raise ValueError("No timestamp column")
         logger.debug("using %s as timestamp column", self.timestamp_column)

--- a/django_querycache/tests/tests.py
+++ b/django_querycache/tests/tests.py
@@ -11,6 +11,7 @@ from tests.models import ModelOfRandomness, ModelOfRandomnessWithLastUpdated
 from django_querycache.cacheman import CachedQuerySet, GeoJsonCachedQuerySet
 from django_querycache.fingerprinting import Fingerprinting, ModelTimeStampedFingerprint
 from django_querycache.hashfunctions import RowHash, SomeColsHash
+from django_querycache.utils import get_ts_field, last_modified_queryset
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +94,21 @@ class TimedTestCase(TestCase):
     def setUp(self):
         for n in range(5):
             ModelOfRandomnessWithLastUpdated().save()
+
+    def test_get_ts_field(self):
+        """
+        Calling this on a model or queryset should
+        return None or a field with `auto_now` if present
+        """
+        self.assertIsNone(get_ts_field(ModelOfRandomness))
+        self.assertEqual(get_ts_field(ModelOfRandomnessWithLastUpdated).name, "last_updated")
+
+    def test_last_modified_queryset(self):
+        self.assertIsNone(last_modified_queryset(ModelOfRandomness))
+        self.assertIsNone(last_modified_queryset(ModelOfRandomness.objects.all()))
+
+        self.assertTrue(isinstance(last_modified_queryset(ModelOfRandomnessWithLastUpdated), str))
+        self.assertTrue(isinstance(last_modified_queryset(ModelOfRandomnessWithLastUpdated.objects.all()), str))
 
     def test_timestampedfingerprint_raises(self):
         """

--- a/django_querycache/utils.py
+++ b/django_querycache/utils.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 from hashlib import md5
-from typing import Optional, Tuple
+from typing import Optional, Sequence, Tuple
 
 from django.apps import apps
 from django.core.cache import cache as default_cache
@@ -93,16 +93,16 @@ def get_ts_field(inputthing: InputModel) -> Optional[Field]:
     A Field instance where "auto_now" is true
     """
     _, model = inputmodel_parse(inputthing)
-    fields = model._meta.fields
+    fields = model._meta.fields  # type: Sequence[Field]
 
     for field in fields:
-        if hasattr(field, "auto_now") and field.auto_now is True:
+        if getattr(field, "auto_now", False):
             return field
     logger.warn("No timestamp column in: %s" % ([f.name for f in fields]))
     return None
 
 
-def last_modified_queryset(inputthing: InputModel) -> str:
+def last_modified_queryset(inputthing: InputModel) -> Optional[str]:
     """
     Returns a [Last-Modified](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified) header
     content for the current queryset, if there is an `auto_now` field present on the model
@@ -115,3 +115,4 @@ def last_modified_queryset(inputthing: InputModel) -> str:
         )
         if dt:
             return dt.strftime(time_format)
+    return None

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,3 +12,6 @@ ignore_missing_imports = True
 
 [mypy-tests.models]
 ignore_missing_imports = True
+
+[mypy-rest_framework.*]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-querycache"
-version = "0.2.2"
+version = "0.2.3"
 description = "Cache manager for Django querysets and serialization"
 authors = ["Joshua Brooks <josh.vdbroek@gmail.com>"]
 license = "GPLv3"


### PR DESCRIPTION
Closes #8

## Description

This PR adds functions to add "headers" to a DRF ModelViewSet. This will let us:
 - Receive an "ETag" header from the server
 - Send an "If-None-Match" header to the server. If unchanged, we'll get a 304.


## Explanation of the solution

Some refactoring, most of the work is in adding mixins for DRF
